### PR TITLE
Add a dependence for exp04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "pytest>=7.4.2",
         "tqdm>=4.66.1",
         "pytorch_lightning>=2.0.1",
+        "tensorboardX>=2.6.2.2",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
I installed `dear` in a new conda env and `tensorboardX` was required for exp 04.